### PR TITLE
Allow explicit tls1.0, tls1.1, tls1.2 for startTLS

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -1,6 +1,11 @@
 Changelog
 =========
 
+5.4.10 (2018-07-03)
+------------------
+
+ * fixed startTLS only allowed tls1.0, now allowed: tls1.0, tls1.1, tls1.2
+
 5.4.9 (2018-01-23)
 ------------------
 

--- a/lib/classes/Swift/Transport/StreamBuffer.php
+++ b/lib/classes/Swift/Transport/StreamBuffer.php
@@ -91,7 +91,11 @@ class Swift_Transport_StreamBuffer extends Swift_ByteStream_AbstractFilterableIn
 
     public function startTLS()
     {
-        return stream_socket_enable_crypto($this->_stream, true, STREAM_CRYPTO_METHOD_TLS_CLIENT);
+        // STREAM_CRYPTO_METHOD_TLS_CLIENT only allow tls1.0 connections (some php versions)
+        // To support modern tls we allow explicit tls1.0, tls1.1, tls1.2
+        // Ssl3 and older are not allowed because they are vulnerable
+        // @TODO make tls arguments configurable
+        return stream_socket_enable_crypto($this->_stream, true, STREAM_CRYPTO_METHOD_TLSv1_0_CLIENT | STREAM_CRYPTO_METHOD_TLSv1_1_CLIENT | STREAM_CRYPTO_METHOD_TLSv1_2_CLIENT);
     }
 
     /**


### PR DESCRIPTION

| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| Doc update?   | yes
| BC breaks?    | no
| Deprecations? | no
| Fixed tickets | #1099
| License       | MIT


Related to https://github.com/swiftmailer/swiftmailer/issues/1099